### PR TITLE
Override Tables variables before global variables

### DIFF
--- a/DirectOutput/LedControl/Loader/LedControlConfig.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfig.cs
@@ -263,7 +263,7 @@ namespace DirectOutput.LedControl.Loader
                 return;
             }
 
-            //Solve tables variables first in case they override global variables (like custom flasher mx shapes)
+            //Resolve tables variables first in case they override global variables (like custom flasher mx shapes)
             if (TableVariableData != null) {
                 Log.Write("Resolving Tables Variables");
                 ResolveTableVariables(OutData, TableVariableData);

--- a/DirectOutput/LedControl/Loader/LedControlConfig.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -263,17 +263,17 @@ namespace DirectOutput.LedControl.Loader
                 return;
             }
 
-            if (VariableData != null)
-            {
-                ResolveVariables(OutData, VariableData);
-            }
-
-            if (TableVariableData != null)
-            {
+            //Solve tables variables first in case they override global variables (like custom flasher mx shapes)
+            if (TableVariableData != null) {
+                Log.Write("Resolving Tables Variables");
                 ResolveTableVariables(OutData, TableVariableData);
             }
 
-
+            if (VariableData != null)
+            {
+                Log.Write("Resolving Global Variables");
+                ResolveVariables(OutData, VariableData);
+            }
 
             ColorConfigurations.ParseLedControlData(ColorData, ThrowExceptions);
 
@@ -327,12 +327,11 @@ namespace DirectOutput.LedControl.Loader
                             }
                         }
                     }
-
                 }
                 if (Updated)
                 {
                     DataToResolve[i] = D;
-                   
+                  
                 }
             }
 

--- a/DirectOutput/LedControl/Loader/TableVariablesDictionary.cs
+++ b/DirectOutput/LedControl/Loader/TableVariablesDictionary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -83,7 +83,6 @@ namespace DirectOutput.LedControl.Loader
                         if (!this[TableName].ContainsKey(VarName))
                         {
                             this[TableName].Add(VarName, Value);
-
                         }
                         else
                         {

--- a/DirectOutput/LedControl/Setup/Configurator.cs
+++ b/DirectOutput/LedControl/Setup/Configurator.cs
@@ -113,7 +113,7 @@ namespace DirectOutput.LedControl.Setup
                                                 }
                                             }
 
-                                            Log.Debug("Setting up shape effect for area. L: {0}, T: {1}, W: {2}, H: {3}".Build(new object[] { TCS.AreaLeft, TCS.AreaTop, TCS.AreaWidth, TCS.AreaHeight }));
+                                            Log.Debug("Setting up shape effect for area. L: {0}, T: {1}, W: {2}, H: {3}, Name: {4}".Build(new object[] { TCS.AreaLeft, TCS.AreaTop, TCS.AreaWidth, TCS.AreaHeight, TCS.ShapeName }));
                                             if (ActiveColor != null)
                                             {
                                                 RGBAColor InactiveColor = ActiveColor.Clone();


### PR DESCRIPTION
Hi !
while digging into per table customization for FlasherMx shapes, i realize that when applying the TablesVariables before the GlobalVariables you can really easily change your flasherMX shapes.

For instance on totan i can simply set this line in TablesVariables :

- totan,flshemulo=AH100 AL0 AT0 AW19 SHPLetterT/flshemuli=AH100 AL20 AT0 AW19 SHPLetterO/flshemuc=AH100 AL40 AT0 AW19 SHPLetterT/flshemuri=AH100 AL60 AT0 AW19 SHPLetterA/flshemuro=AH100 AL80 AT0 AW19 SHPLetterN

to have the whole FlashersMX effects updated without changing all of them in the dofConfigTool.

It makes it really easy to customize flashers per table without heavy maintenance because only one line is overridden in the DofConfigTool.

There is only one TableVariable set officially (black100) and those flasher override can be added to the other variables without any problem, so it shouldn't be an issue afaik.
