### PR TITLE
Configurable TeensyController : new SendPerLedstripLength option following Wemos firmware upgrade

### DIFF
--- a/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
+++ b/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
@@ -332,6 +332,22 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
             }
         }
 
+        private bool _SendPerLedstripLength = false;
+
+        /// <summary>
+        /// Set if the controller will send per ledstrip length commands during the handshake.
+        /// </summary>
+        /// <value>
+        /// true if the commands are sent
+        /// </value>
+        public bool SendPerLedstripLength
+        {
+            get { return _SendPerLedstripLength; }
+            set {
+                _SendPerLedstripLength = value;
+            }
+        }
+
         /// <summary>
         /// This method returns the sum of the number of leds configured for the 8 output channels of the Teensy board.
         /// </summary>
@@ -618,21 +634,22 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
             }
 
             //Send number of leds per leds strips
-            //It's optional, so Nack are accepted
-            for (var numled = 0; numled < NumberOfLedsPerStrip.Length; ++numled) {
-                int nbleds = NumberOfLedsPerStrip[numled];
-                CommandData = new byte[5] { (byte)'Z', (byte)numled, (byte)(NumberOfLedsPerStrip.Length-1), (byte)(nbleds >> 8), (byte)(nbleds & 255) };
-                ComPort.Write(CommandData, 0, 5);
-                ReceiveData = new byte[1];
-                BytesRead = -1;
-                try {
-                    BytesRead = ReadPortWait(ReceiveData, 0, 1);
-                } catch (Exception E) {
-                    throw new Exception($"Expected 1 bytes after setting the number of leds per ledstrip for strip {numled} , but the read operation resulted in a exception. Will not send data to the controller.", E);
-                }
+            if (SendPerLedstripLength) {
+                for (var numled = 0; numled < NumberOfLedsPerStrip.Length; ++numled) {
+                    int nbleds = NumberOfLedsPerStrip[numled];
+                    CommandData = new byte[5] { (byte)'Z', (byte)numled, (byte)(NumberOfLedsPerStrip.Length - 1), (byte)(nbleds >> 8), (byte)(nbleds & 255) };
+                    ComPort.Write(CommandData, 0, 5);
+                    ReceiveData = new byte[1];
+                    BytesRead = -1;
+                    try {
+                        BytesRead = ReadPortWait(ReceiveData, 0, 1);
+                    } catch (Exception E) {
+                        throw new Exception($"Expected 1 bytes after setting the number of leds for ledstrip {numled} , but the read operation resulted in a exception. Will not send data to the controller.", E);
+                    }
 
-                if (BytesRead != 1 || (ReceiveData[0] != (byte)'A' && ReceiveData[0] != (byte)'N')) {
-                    throw new Exception($"Expected a Ack (A) or a Nack (N) after setting the number of leds per ledstrip for strip {numled}, but received no answer or a unexpected answer. Will not send data to the controller.");
+                    if (BytesRead != 1 || ReceiveData[0] != (byte)'A') {
+                        throw new Exception($"Expected a Ack (A) after setting the number of leds for ledstrip {numled}, but received no answer or a unexpected answer. Will not send data to the controller.");
+                    }
                 }
             }
 

--- a/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
+++ b/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
@@ -640,18 +640,20 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
             if (SendPerLedstripLength) {
                 for (var numled = 0; numled < NumberOfLedsPerStrip.Length; ++numled) {
                     int nbleds = NumberOfLedsPerStrip[numled];
-                    CommandData = new byte[5] { (byte)'Z', (byte)numled, (byte)(NumberOfLedsPerStrip.Length - 1), (byte)(nbleds >> 8), (byte)(nbleds & 255) };
-                    ComPort.Write(CommandData, 0, 5);
-                    ReceiveData = new byte[1];
-                    BytesRead = -1;
-                    try {
-                        BytesRead = ReadPortWait(ReceiveData, 0, 1);
-                    } catch (Exception E) {
-                        throw new Exception($"Expected 1 bytes after setting the number of leds for ledstrip {numled} , but the read operation resulted in a exception. Will not send data to the controller.", E);
-                    }
+                    if (nbleds > 0) {
+                        CommandData = new byte[5] { (byte)'Z', (byte)numled, (byte)(NumberOfLedsPerStrip.Length - 1), (byte)(nbleds >> 8), (byte)(nbleds & 255) };
+                        ComPort.Write(CommandData, 0, 5);
+                        ReceiveData = new byte[1];
+                        BytesRead = -1;
+                        try {
+                            BytesRead = ReadPortWait(ReceiveData, 0, 1);
+                        } catch (Exception E) {
+                            throw new Exception($"Expected 1 bytes after setting the number of leds for ledstrip {numled} , but the read operation resulted in a exception. Will not send data to the controller.", E);
+                        }
 
-                    if (BytesRead != 1 || ReceiveData[0] != (byte)'A') {
-                        throw new Exception($"Expected a Ack (A) after setting the number of leds for ledstrip {numled}, but received no answer or a unexpected answer ({(char)ReceiveData[0]}). Will not send data to the controller.");
+                        if (BytesRead != 1 || ReceiveData[0] != (byte)'A') {
+                            throw new Exception($"Expected a Ack (A) after setting the number of leds for ledstrip {numled}, but received no answer or a unexpected answer ({(char)ReceiveData[0]}). Will not send data to the controller.");
+                        }
                     }
                 }
             }

--- a/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
+++ b/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
@@ -617,6 +617,25 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
 
             }
 
+            //Send number of leds per leds strips
+            //It's optional, so Nack are accepted
+            for (var numled = 0; numled < NumberOfLedsPerStrip.Length; ++numled) {
+                int nbleds = NumberOfLedsPerStrip[numled];
+                CommandData = new byte[5] { (byte)'Z', (byte)numled, (byte)(NumberOfLedsPerStrip.Length-1), (byte)(nbleds >> 8), (byte)(nbleds & 255) };
+                ComPort.Write(CommandData, 0, 5);
+                ReceiveData = new byte[1];
+                BytesRead = -1;
+                try {
+                    BytesRead = ReadPortWait(ReceiveData, 0, 1);
+                } catch (Exception E) {
+                    throw new Exception($"Expected 1 bytes after setting the number of leds per ledstrip for strip {numled} , but the read operation resulted in a exception. Will not send data to the controller.", E);
+                }
+
+                if (BytesRead != 1 || (ReceiveData[0] != (byte)'A' && ReceiveData[0] != (byte)'N')) {
+                    throw new Exception($"Expected a Ack (A) or a Nack (N) after setting the number of leds per ledstrip for strip {numled}, but received no answer or a unexpected answer. Will not send data to the controller.");
+                }
+            }
+
             //Clear the buffer and turn off the leds.
             CommandData = new byte[1] { (byte)'C' };
             ComPort.Write(CommandData, 0, 1);

--- a/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
+++ b/DirectOutput/Cab/Out/AdressableLedStrip/TeensyStripController.cs
@@ -340,6 +340,9 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
         /// <value>
         /// true if the commands are sent
         /// </value>
+        /// <remarks>
+        /// These commands are supported by the new Wemos firmware from yoyofr & aetios50, supporting dynamic ledstrip length setup (part of an overall performance improvement)
+        /// </remarks>
         public bool SendPerLedstripLength
         {
             get { return _SendPerLedstripLength; }
@@ -633,7 +636,7 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
 
             }
 
-            //Send number of leds per leds strips
+            //Send number of leds per leds strips 
             if (SendPerLedstripLength) {
                 for (var numled = 0; numled < NumberOfLedsPerStrip.Length; ++numled) {
                     int nbleds = NumberOfLedsPerStrip[numled];
@@ -648,7 +651,7 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
                     }
 
                     if (BytesRead != 1 || ReceiveData[0] != (byte)'A') {
-                        throw new Exception($"Expected a Ack (A) after setting the number of leds for ledstrip {numled}, but received no answer or a unexpected answer. Will not send data to the controller.");
+                        throw new Exception($"Expected a Ack (A) after setting the number of leds for ledstrip {numled}, but received no answer or a unexpected answer ({(char)ReceiveData[0]}). Will not send data to the controller.");
                     }
                 }
             }


### PR DESCRIPTION
Hi !
Following some optimisations made by yoyofr (https://github.com/yoyofr/PincabLedStrip) & aetios50 (https://github.com/aetios50/PincabLedStrip) on the Wemos D1 Firmware, i've added a new option to be able to send a specific length for each ledstrip to the controller.

It's setup in cabinet.xml setting the SendPerLedstripLength option to true.
'Z' commands are sent to the controller for each non zero sized ledstrip.
Command format is as follows : 'Z', ledstrip_index(zero based, byte), last_index(zero based, byte), length (ushort)
It's backward compatible if this option is not set.

Cheers !