### PR TITLE
fadeeffect : fixed missing UnregisterIntervalAlarm in FadeEffect

### DIFF
--- a/DirectOutput/FX/TimmedFX/FadeEffect.cs
+++ b/DirectOutput/FX/TimmedFX/FadeEffect.cs
@@ -114,6 +114,7 @@ namespace DirectOutput.FX.TimmedFX
             }
             else
             {
+                Table.Pinball.Alarms.UnregisterIntervalAlarm(FadingStep);
                 CurrentValue = TargetValue;
             }
 


### PR DESCRIPTION
Seems there was a missing unregister for this Alarm.
Saw that it was stacking Interval alarms each time a fade effect is triggered.
Could lead to quite a lot of delegate callbacks after long playing sessions.