### PR TITLE
Bitmapeffects fixes

### DIFF
--- a/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
@@ -329,7 +329,7 @@ namespace DirectOutput.FX.MatrixFX
             if (BitmapFilePattern.IsValid)
             {
 
-                string Filename = BitmapFilePattern.GetFirstMatchingFile(Table.Pinball.GlobalConfig.GetReplaceValuesDictionary()).FullName;
+                string Filename = BitmapFilePattern.GetFirstMatchingFile(Table.Pinball.GlobalConfig.GetReplaceValuesDictionary())?.FullName ?? string.Empty;
                 if (!Filename.IsNullOrWhiteSpace())
                 {
                     FastImage BM;

--- a/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
@@ -193,30 +193,25 @@ namespace DirectOutput.FX.MatrixFX
         private int AnimationFadeValue = 0;
         private void Animate()
         {
-            
 
-            for (int y = 0; y < AreaHeight; y++)
-            {
-                int yd = y + AreaTop;
-                for (int x = 0; x < AreaWidth; x++)
-                {
-                    int xd = x + AreaLeft;
-                    MatrixLayer[xd, yd] = GetEffectValue(AnimationFadeValue, Pixels[AnimationStep][x, y]);
+            if (AnimationStep <= Pixels.GetUpperBound(0)) {
+                for (int y = 0; y < AreaHeight; y++) {
+                    int yd = y + AreaTop;
+                    for (int x = 0; x < AreaWidth; x++) {
+                        int xd = x + AreaLeft;
+                        MatrixLayer[xd, yd] = GetEffectValue(AnimationFadeValue, Pixels[AnimationStep][x, y]);
+                    }
                 }
-            }
-
-          
-
-            AnimationStep++;
-            if (AnimationStep >= Pixels.GetUpperBound(0))
-            {
+                AnimationStep++;
+                if (AnimationBehaviour != AnimationBehaviourEnum.Once) {
+                    AnimationStep = AnimationStep % (Pixels.GetUpperBound(0) + 1);
+                }
+            } else {
                 AnimationStep = 0;
-                if (AnimationBehaviour == AnimationBehaviourEnum.Once)
-                {
+                if (AnimationBehaviour == AnimationBehaviourEnum.Once) {
                     StopAnimation();
                 }
             }
-
         }
 
         private void Clear()

--- a/DirectOutput/General/BitmapHandling/FastImage.cs
+++ b/DirectOutput/General/BitmapHandling/FastImage.cs
@@ -43,6 +43,7 @@ namespace DirectOutput.General.BitmapHandling
                 Frames.Add(FrameNumber, F);
             }
 
+            Img.Dispose();
         }
 
 

--- a/DirectOutput/General/Generic/NamedItemList.cs
+++ b/DirectOutput/General/Generic/NamedItemList.cs
@@ -45,13 +45,16 @@ namespace DirectOutput.General.Generic
 
         void NamedItemList_BeforeClear(object sender, EventArgs e)
         {
-            foreach (T Item in this)
-            {
+            foreach (T Item in this) {
                 Item.BeforeNameChanged -= new EventHandler<NameChangeEventArgs>(Item_BeforeNameChange);
                 Item.AfterNameChanged -= new EventHandler<NameChangeEventArgs>(Item_AfterNameChanged);
             }
         }
 
+        void NamedItemList_AfterClear(object sender, EventArgs e)
+        {
+            _NameDict.Clear();
+        }
 
         void Item_AfterNameChanged(object sender, NameChangeEventArgs e)
         {
@@ -158,6 +161,7 @@ namespace DirectOutput.General.Generic
             this.AfterSet += new EventHandler<SetEventArgs<T>>(NamedItemList_AfterSet);
             this.AfterRemove += new EventHandler<RemoveEventArgs<T>>(NamedItemList_AfterRemove);
             this.BeforeClear += new EventHandler<EventArgs>(NamedItemList_BeforeClear);
+            this.AfterClear += new EventHandler<EventArgs>(NamedItemList_AfterClear);
         }
 
 


### PR DESCRIPTION
Hi !

While investigating through MatrixBitmapAnimationEffect for my DOTK, I found a few issues : 

- _NameDict member is not cleared when clearing NamesItemList
- Some frames were missing in some modes while playing MatrixBitmapAnimationEffect.
- Image provided to FastImage for frames extraction was not disposed
- When the image file was not present using a MatrixBitmapAnimationEffect, DirectOutput was crashing

Cheers
