### PR TITLE
LogLevel support for Log, hide Debug messages until set in globalconfig (easier log analysis)

### DIFF
--- a/DirectOutput/Cab/Out/AdressableLedStrip/WemosD1StripController.cs
+++ b/DirectOutput/Cab/Out/AdressableLedStrip/WemosD1StripController.cs
@@ -79,7 +79,7 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
                     int nbleds = NumberOfLedsPerStrip[numled];
                     if (nbleds > 0) {
                         CommandData = new byte[5] { (byte)'Z', (byte)numled, (byte)(NumberOfLedsPerStrip.Length - 1), (byte)(nbleds >> 8), (byte)(nbleds & 255) };
-                        Log.Debug($"Resize ledstrip {numled} to {nbleds} leds.");
+                        Log.Write($"Resize ledstrip {numled} to {nbleds} leds.");
                         ComPort.Write(CommandData, 0, 5);
                         ReceiveData = new byte[1];
                         BytesRead = -1;
@@ -98,7 +98,7 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
 
             if (TestOnConnect) {
                 CommandData = new byte[1] { (byte)'T' };
-                Log.Debug($"Send a test request to the controller");
+                Log.Write($"Send a test request to the controller");
                 ComPort.Write(CommandData, 0, 1);
 
                 //Temporary wait before asking the Ack

--- a/DirectOutput/Cab/Out/DudesCab/DudesCab.cs
+++ b/DirectOutput/Cab/Out/DudesCab/DudesCab.cs
@@ -171,7 +171,7 @@ namespace DirectOutput.Cab.Out.DudesCab
                             extensionChangeMask |= (byte)(1 << numExt);
                             outputsChangeMask[numExt] |= (ushort)(1 << numOuput);
                             outputBuffer.Add(NewOutputValues[outputOffset]);
-                            Log.Debug($"Output {outputOffset + 1} ({OldOutputValues[outputOffset]}=>{NewOutputValues[outputOffset]}) is sent to an extension ({numExt + 1})");
+                            Log.Instrumentation("DudesCab", $"Output {outputOffset + 1} ({OldOutputValues[outputOffset]}=>{NewOutputValues[outputOffset]}) is sent to an extension ({numExt + 1})");
                         } else {
                             if (!firstInit) {
                                 Log.Warning($"Output {outputOffset + 1} ({OldOutputValues[outputOffset]}=>{NewOutputValues[outputOffset]}) is sent to an extension ({numExt + 1}) which wasn't configured on the DudesCab Controller, Please check your Controller or Dof settings");
@@ -181,7 +181,7 @@ namespace DirectOutput.Cab.Out.DudesCab
                 }
 
                 if (outputsChangeMask[numExt] != 0) {
-                    Log.Debug($"Extenstion {numExt + 1} OutputsMask {(int)outputsChangeMask[numExt]:X4}");
+                    Log.Instrumentation("DudesCab", $"Extenstion {numExt + 1} OutputsMask {(int)outputsChangeMask[numExt]:X4}");
                     outputBuffer[maskOffset] = (byte)(outputsChangeMask[numExt] & 0xFF);
                     outputBuffer[maskOffset + 1] = (byte)((outputsChangeMask[numExt] >> 8) & 0xFF);
                 } else {
@@ -191,7 +191,7 @@ namespace DirectOutput.Cab.Out.DudesCab
 
             if (extensionChangeMask != 0) {
                 outputBuffer[0] = extensionChangeMask;
-                Log.Debug($"ExtenstionMask {outputBuffer[0]:X2}");
+                Log.Instrumentation("DudesCab", $"ExtenstionMask {outputBuffer[0]:X2}");
                 Dev.SendCommand(Device.HIDReportType.RT_PWM_OUTPUTS, outputBuffer.ToArray());
             }
             firstInit = false;
@@ -418,7 +418,7 @@ namespace DirectOutput.Cab.Out.DudesCab
                     data = data.ToList().Concat(parameters).ToArray();
                 }
 
-                Log.Debug($"DudesCab SendCommand: {command}, [{string.Join(",", data.ToArray())}]");
+                Log.Instrumentation("DudesCab", $"DudesCab SendCommand: {command}, [{string.Join(",", data.ToArray())}]");
 
                 //Compute how many parts will be needed to send the command, based on the provided DudesCab caps.
                 byte bufferOffset = 5;

--- a/DirectOutput/Cab/Out/DudesCab/DudesCab.cs
+++ b/DirectOutput/Cab/Out/DudesCab/DudesCab.cs
@@ -26,8 +26,6 @@ namespace DirectOutput.Cab.Out.DudesCab
         public static readonly ushort VendorID = 0x2E8A;
         public static readonly ushort ProductID = 0x106F;
 
-        public static readonly bool DebugCommunication = false;
-
         #region Number
 
 
@@ -173,8 +171,7 @@ namespace DirectOutput.Cab.Out.DudesCab
                             extensionChangeMask |= (byte)(1 << numExt);
                             outputsChangeMask[numExt] |= (ushort)(1 << numOuput);
                             outputBuffer.Add(NewOutputValues[outputOffset]);
-                            if (DebugCommunication)
-                                Log.Debug($"Output {outputOffset + 1} ({OldOutputValues[outputOffset]}=>{NewOutputValues[outputOffset]}) is sent to an extension ({numExt + 1})");
+                            Log.Debug($"Output {outputOffset + 1} ({OldOutputValues[outputOffset]}=>{NewOutputValues[outputOffset]}) is sent to an extension ({numExt + 1})");
                         } else {
                             if (!firstInit) {
                                 Log.Warning($"Output {outputOffset + 1} ({OldOutputValues[outputOffset]}=>{NewOutputValues[outputOffset]}) is sent to an extension ({numExt + 1}) which wasn't configured on the DudesCab Controller, Please check your Controller or Dof settings");
@@ -184,8 +181,7 @@ namespace DirectOutput.Cab.Out.DudesCab
                 }
 
                 if (outputsChangeMask[numExt] != 0) {
-                    if (DebugCommunication)
-                        Log.Debug($"Extenstion {numExt + 1} OutputsMask {(int)outputsChangeMask[numExt]:X4}");
+                    Log.Debug($"Extenstion {numExt + 1} OutputsMask {(int)outputsChangeMask[numExt]:X4}");
                     outputBuffer[maskOffset] = (byte)(outputsChangeMask[numExt] & 0xFF);
                     outputBuffer[maskOffset + 1] = (byte)((outputsChangeMask[numExt] >> 8) & 0xFF);
                 } else {
@@ -195,8 +191,7 @@ namespace DirectOutput.Cab.Out.DudesCab
 
             if (extensionChangeMask != 0) {
                 outputBuffer[0] = extensionChangeMask;
-                if (DebugCommunication)
-                    Log.Debug($"ExtenstionMask {outputBuffer[0]:X2}");
+                Log.Debug($"ExtenstionMask {outputBuffer[0]:X2}");
                 Dev.SendCommand(Device.HIDReportType.RT_PWM_OUTPUTS, outputBuffer.ToArray());
             }
             firstInit = false;
@@ -423,8 +418,7 @@ namespace DirectOutput.Cab.Out.DudesCab
                     data = data.ToList().Concat(parameters).ToArray();
                 }
 
-                if (DebugCommunication)
-                    Log.Write($"DudesCab SendCommand: {command}, [{string.Join(",", data.ToArray())}]");
+                Log.Debug($"DudesCab SendCommand: {command}, [{string.Join(",", data.ToArray())}]");
 
                 //Compute how many parts will be needed to send the command, based on the provided DudesCab caps.
                 byte bufferOffset = 5;

--- a/DirectOutput/Cab/Out/LW/LedWiz.cs
+++ b/DirectOutput/Cab/Out/LW/LedWiz.cs
@@ -174,7 +174,7 @@ namespace DirectOutput.Cab.Out.LW
         /// <param name="Cabinet">The Cabinet object which is using the LedWiz instance.</param>
         public override void Init(Cabinet Cabinet)
         {
-            Log.Debug("Initializing LedWiz Nr. {0:00}".Build(Number));
+            Log.Write("Initializing LedWiz Nr. {0:00}".Build(Number));
             AddOutputs();
             if (!MinCommandIntervalMsSet && Cabinet.Owner.ConfigurationSettings.ContainsKey("LedWizDefaultMinCommandIntervalMs") && Cabinet.Owner.ConfigurationSettings["LedWizDefaultMinCommandIntervalMs"] is int)
             {
@@ -193,7 +193,7 @@ namespace DirectOutput.Cab.Out.LW
         /// </summary>
         public override void Finish()
         {
-            Log.Debug("Finishing LedWiz Nr. {0:00}".Build(Number));
+            Log.Write("Finishing LedWiz Nr. {0:00}".Build(Number));
             LedWizUnits[Number].Finish();
             LedWizUnits[Number].ShutdownLighting();
             Log.Write("LedWiz Nr. {0:00} finished and updater thread stopped.".Build(Number));
@@ -1172,10 +1172,10 @@ namespace DirectOutput.Cab.Out.LW
 						// if that failed, give it a moment before trying again
 						Thread.Sleep(RetryWait[tries]);
 					}
-					Log.Write(String.Format("LedWiz {0} WriteUSB failed after {1} retries", Number, RetryWait.Length));
+					Log.Error(String.Format("LedWiz {0} WriteUSB failed after {1} retries", Number, RetryWait.Length));
 				}
 				else
-					Log.Write(String.Format("LedWiz {0} WriteUSB has no file handle", Number));
+					Log.Error(String.Format("LedWiz {0} WriteUSB has no file handle", Number));
 			}
 
             private bool IsPresent

--- a/DirectOutput/Cab/Out/PS/Pinscape.cs
+++ b/DirectOutput/Cab/Out/PS/Pinscape.cs
@@ -342,12 +342,12 @@ namespace DirectOutput.Cab.Out.PS
 						if (TryReopenHandle())
 							continue;
 
-						Log.Write("Pinscape Controller USB error reading from device: " + GetLastWin32ErrMsg());
+						Log.Error("Pinscape Controller USB error reading from device: " + GetLastWin32ErrMsg());
 						return null;
 					}
 					else if (actual != inputReportByteLength)
 					{
-						Log.Write("Pinscape Controller USB error reading from device: not all bytes received");
+						Log.Error("Pinscape Controller USB error reading from device: not all bytes received");
 						return null;
 					}
 					else
@@ -371,7 +371,7 @@ namespace DirectOutput.Cab.Out.PS
 				if (Marshal.GetLastWin32Error() == 6)
 				{
 					// try opening a new handle on the device path
-					Log.Write("Pinscape Controller: invalid handle on read; trying to reopen handle");
+					Log.Error("Pinscape Controller: invalid handle on read; trying to reopen handle");
 					IntPtr fp2 = OpenFile();
 
 					// if that succeeded, replace the old handle with the new one and retry the read
@@ -421,12 +421,12 @@ namespace DirectOutput.Cab.Out.PS
 						if (TryReopenHandle())
 							continue;
 
-						Log.Write("Pinscape Controller USB error sending request to device: " + GetLastWin32ErrMsg());
+						Log.Error("Pinscape Controller USB error sending request to device: " + GetLastWin32ErrMsg());
 						return false;
 					}
 					else if (actual != 9)
 					{
-						Log.Write("Pinscape Controller USB error sending request: not all bytes sent");
+						Log.Error("Pinscape Controller USB error sending request: not all bytes sent");
 						return false;
 					}
 					else

--- a/DirectOutput/Cab/Out/PSPico/PinscapePico.cs
+++ b/DirectOutput/Cab/Out/PSPico/PinscapePico.cs
@@ -532,7 +532,7 @@ namespace DirectOutput.Cab.Out.PSPico
 						timeBuf[7] = (byte)now.Minute;
 						timeBuf[8] = (byte)now.Second;
 						if (!WriteUSB("SET WALL CLOCK TIME", timeBuf, 100))
-							Log.Write("Pinscape Pico: warning: error setting wall clock time");
+							Log.Warning("Pinscape Pico: error setting wall clock time");
 
 						// we found the response, so we can stop searching for it
 						identified = true;
@@ -543,7 +543,7 @@ namespace DirectOutput.Cab.Out.PSPico
 				// make sure we identified the device
 				if (!identified)
 				{
-					Log.Write(("ERROR: Pinscape Pico VID/PID {X4/X4} did not respond to identification query; "
+					Log.Error(("Pinscape Pico VID/PID {X4/X4} did not respond to identification query; "
 						+ "this device's output port configuration is unknown, so no port updates will be sent "
 						+ "to it during this session").Build(
 						vendorID, productID));
@@ -609,14 +609,14 @@ namespace DirectOutput.Cab.Out.PSPico
 						break;
 
 					// read or wait failed - log the error and return failure
-					Log.Write("Pinscape Pico: USB error reading from device: " + GetLastWin32ErrMsg());
+					Log.Error("Pinscape Pico: USB error reading from device: " + GetLastWin32ErrMsg());
 					return null;
 				}
 
 				// check that the actual byte length read matches the request
 				if (actual != inputReportByteLength)
 				{
-					Log.Write("Pinscape Pico: USB error reading from device: not all bytes received");
+					Log.Error("Pinscape Pico: USB error reading from device: not all bytes received");
 					return null;
 				}
 					
@@ -648,14 +648,14 @@ namespace DirectOutput.Cab.Out.PSPico
 						break;
 
 					// write or wait failed - log the error and return failure
-					Log.Write("Pinscape Pico: USB error sending to device ({0}): {1}".Build(desc, GetLastWin32ErrMsg()));
+					Log.Error("Pinscape Pico: USB error sending to device ({0}): {1}".Build(desc, GetLastWin32ErrMsg()));
 					return false;
 				}
 
 				// check that the actual byte length written matches the request
 				if (actual != outputReportByteLength)
 				{
-					Log.Write("Pinscape Pico: USB error sending to device ({0}): not all bytes sent".Build(desc));
+					Log.Error("Pinscape Pico: USB error sending to device ({0}): not all bytes sent".Build(desc));
 					return false;
 				}
 
@@ -676,7 +676,7 @@ namespace DirectOutput.Cab.Out.PSPico
 				if (Marshal.GetLastWin32Error() == ERROR_INVALID_HANDLE)
 				{
 					// try opening a new handle on the device path
-					Log.Write("Pinscape Pico: invalid handle on read; trying to reopen handle");
+					Log.Error("Pinscape Pico: invalid handle on read; trying to reopen handle");
 					IntPtr fp2 = OpenFile();
 
 					// if that succeeded, replace the old handle with the new one and retry the read

--- a/DirectOutput/Cab/Out/SSF/SSFImpactController.cs
+++ b/DirectOutput/Cab/Out/SSF/SSFImpactController.cs
@@ -284,7 +284,7 @@ namespace DirectOutput.Cab.Out.SSFImpactController
 
                         if ((stream == 0) && (Bass.LastError == Errors.Speaker))
                         {
-                            Log.Write("Unable to assign FrontExciters stream to speakers: " + _FrontExciters);
+                            Log.Warning("Unable to assign FrontExciters stream to speakers: " + _FrontExciters);
                         }
 
 
@@ -295,13 +295,13 @@ namespace DirectOutput.Cab.Out.SSFImpactController
                         stream = Bass.CreateStream(ssfStream.ToArray(), 0, ssfStream.Length, (BassFlags)_FrontExciterPair);
                         if ((stream == 0) && (Bass.LastError == Errors.Speaker))
                         {
-                             Log.Write("Unable to assign FrontExciters stream to speakers: " + _FrontExciters);
+                             Log.Warning("Unable to assign FrontExciters stream to speakers: " + _FrontExciters);
                         }
 
                         stream1 = Bass.CreateStream(ssfStream.ToArray(), 0, ssfStream.Length, (BassFlags)_RearExciterPair);
                         if ((stream1 == 0) && (Bass.LastError == Errors.Speaker))
                         {
-                            Log.Write("Unable to assign RearExciters stream to speakers: " + _RearExciters);
+                            Log.Warning("Unable to assign RearExciters stream to speakers: " + _RearExciters);
                         }
 
 
@@ -329,7 +329,7 @@ namespace DirectOutput.Cab.Out.SSFImpactController
                 }
                 catch (Exception e)
                 {
-                    Log.Write("Could Not Initialze Bass - " + e.Message);
+                    Log.Error("Could Not Initialze Bass - " + e.Message);
                 }
             }
 
@@ -361,7 +361,7 @@ namespace DirectOutput.Cab.Out.SSFImpactController
             }
             catch (Exception)
             {
-                Log.Write("Bass subsystem was not initialized");
+                Log.Error("Bass subsystem was not initialized");
             }
 
         }
@@ -472,7 +472,7 @@ namespace DirectOutput.Cab.Out.SSFImpactController
             catch (Exception e)
             {
 
-                Log.Write("UPDATE EXCEPTION:: " + e.Message);
+                Log.Error("UPDATE EXCEPTION:: " + e.Message);
             }
 
         }
@@ -734,7 +734,7 @@ namespace DirectOutput.Cab.Out.SSFImpactController
                     Log.Write("BassShaker set to speaker:" + SSFImpactController.SpeakerNames[(BassFlags)_ShakerChannel1]);
                     if ((running == 0) && (Bass.LastError == Errors.Speaker))
                     {
-                        Log.Write("Unable to assign Shaker1 stream to speakers: " + _BassShaker1);
+                        Log.Warning("Unable to assign Shaker1 stream to speakers: " + _BassShaker1);
                         return;
                     }
                 }
@@ -745,7 +745,7 @@ namespace DirectOutput.Cab.Out.SSFImpactController
                     Log.Write("Additional BassShaker set to speaker:" + SSFImpactController.SpeakerNames[(BassFlags)_ShakerChannel2]);
                     if ((running2 == 0) && (Bass.LastError == Errors.Speaker))
                     {
-                        Log.Write("Unable to assign Shaker2 stream to speakers: " + _BassShaker2);
+                        Log.Warning("Unable to assign Shaker2 stream to speakers: " + _BassShaker2);
                         return;
                     }
                 }
@@ -794,7 +794,7 @@ namespace DirectOutput.Cab.Out.SSFImpactController
             }
             catch (Exception)
             {
-                Log.Write("Could Not Initialze Bass. SSFImpactor disabled for events.");
+                Log.Error("Could Not Initialze Bass. SSFImpactor disabled for events.");
                 return;
             }
 

--- a/DirectOutput/DirectOutput.cs
+++ b/DirectOutput/DirectOutput.cs
@@ -113,7 +113,7 @@ namespace DirectOutput
                 Pinball.Finish();
                 Pinball = null;
             } else {
-                Log.Write("DirectOutput.Finish: Pinball is null, unable to shut down cab!");
+                Log.Error("DirectOutput.Finish: Pinball is null, unable to shut down cab!");
             }
 
         }

--- a/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
@@ -393,7 +393,7 @@ namespace DirectOutput.FX.MatrixFX
                                 break;
                         }
 
-                        Log.Debug("BitmapAnimationEffectBase. Grabbed image clips: W: {0}, H:{1}, BML: {2}, BMT: {3}, BMW: {4}, BMH: {5}, Steps: {6}".Build(new object[] { AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, StepCount }));
+                        Log.Instrumentation("MX", "BitmapAnimationEffectBase. Grabbed image clips: W: {0}, H:{1}, BML: {2}, BMT: {3}, BMW: {4}, BMH: {5}, Steps: {6}".Build(new object[] { AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, StepCount }));
 
 
                     }

--- a/DirectOutput/FX/MatrixFX/MatrixBitmapEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapEffectBase.cs
@@ -190,7 +190,7 @@ namespace DirectOutput.FX.MatrixFX
 
                     if (BM.Frames.ContainsKey(BitmapFrameNumber))
                     {
-                        Log.Debug("BitmapEffectBase. Grabbing image clip: W: {0}, H:{1}, BML: {2}, BMT: {3}, BMW: {4}, BMH: {5}".Build(new object[] { AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight }));
+                        Log.Instrumentation("MX", "BitmapEffectBase. Grabbing image clip: W: {0}, H:{1}, BML: {2}, BMT: {3}, BMW: {4}, BMH: {5}".Build(new object[] { AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight }));
                         Pixels = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode).Pixels;
 
                     }

--- a/DirectOutput/FX/MatrixFX/MatrixEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixEffectBase.cs
@@ -226,7 +226,7 @@ namespace DirectOutput.FX.MatrixFX
                 if (AreaLeft > AreaRight) { Tmp = AreaRight; AreaRight = AreaLeft; AreaLeft = AreaRight; }
                 if (AreaTop > AreaBottom) { Tmp = AreaBottom; AreaBottom = AreaTop; AreaTop = Tmp; }
 
-                Log.Debug("MatrixBase for {12}. Calculated area size: AreaDef(L:{0}, T:{1}, W:{2}, H:{3}), Matrix(W:{4}, H:{5}), ResultArea(Left: {6}, Top:{7}, Right:{8}, Bottom:{9}, Width:{10}, Height:{11})".Build(new object[] { Left, Top, Width, Height, Matrix.Height, Matrix.Width, AreaLeft, AreaTop, AreaRight, AreaBottom, AreaWidth, AreaHeight, this.GetType().Name }));
+                Log.Instrumentation("MX", "MatrixBase for {12}. Calculated area size: AreaDef(L:{0}, T:{1}, W:{2}, H:{3}), Matrix(W:{4}, H:{5}), ResultArea(Left: {6}, Top:{7}, Right:{8}, Bottom:{9}, Width:{10}, Height:{11})".Build(new object[] { Left, Top, Width, Height, Matrix.Height, Matrix.Width, AreaLeft, AreaTop, AreaRight, AreaBottom, AreaWidth, AreaHeight, this.GetType().Name }));
 
             }
 

--- a/DirectOutput/GlobalConfiguration/GlobalConfig.cs
+++ b/DirectOutput/GlobalConfiguration/GlobalConfig.cs
@@ -476,6 +476,15 @@ namespace DirectOutput.GlobalConfiguration
             return LogFilePattern.ReplacePlaceholders(R);
         }
 
+
+        private string _LogLevel = "Info";
+
+        public string LogLevel
+        {
+            get { return _LogLevel; }
+            set { _LogLevel = value; }
+        }
+
         #endregion
 
 
@@ -680,7 +689,7 @@ namespace DirectOutput.GlobalConfiguration
                 }
                 else
                 {
-                    Log.Write("Global config file \"" + GlobalConfigFileName + "\" does not exist; no global config loaded");
+                    Log.Error("Global config file \"" + GlobalConfigFileName + "\" does not exist; no global config loaded");
                     return null;
                 }
             }

--- a/DirectOutput/GlobalConfiguration/GlobalConfig.cs
+++ b/DirectOutput/GlobalConfiguration/GlobalConfig.cs
@@ -477,12 +477,12 @@ namespace DirectOutput.GlobalConfiguration
         }
 
 
-        private string _LogLevel = "Info";
+        private string _Instrumentation = string.Empty;
 
-        public string LogLevel
+        public string Instrumentation
         {
-            get { return _LogLevel; }
-            set { _LogLevel = value; }
+            get { return _Instrumentation; }
+            set { _Instrumentation = value; }
         }
 
         #endregion

--- a/DirectOutput/LedControl/Loader/TableConfigSetting.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigSetting.cs
@@ -396,7 +396,7 @@ namespace DirectOutput.LedControl.Loader
                                 }
                                 else
                                 {
-                                    Log.Write("Failed: " + E);
+                                    Log.Error("Failed: " + E);
                                     ParseOK = false;
                                     break;
                                 }

--- a/DirectOutput/LedControl/Setup/Configurator.cs
+++ b/DirectOutput/LedControl/Setup/Configurator.cs
@@ -106,7 +106,7 @@ namespace DirectOutput.LedControl.Setup
                                                 }
                                             }
 
-                                            Log.Debug("Setting up shape effect for area. L: {0}, T: {1}, W: {2}, H: {3}, Name: {4}".Build(new object[] { TCS.AreaLeft, TCS.AreaTop, TCS.AreaWidth, TCS.AreaHeight, TCS.ShapeName }));
+                                            Log.Instrumentation("MX", "Setting up shape effect for area. L: {0}, T: {1}, W: {2}, H: {3}, Name: {4}".Build(new object[] { TCS.AreaLeft, TCS.AreaTop, TCS.AreaWidth, TCS.AreaHeight, TCS.ShapeName }));
                                             if (ActiveColor != null)
                                             {
                                                 RGBAColor InactiveColor = ActiveColor.Clone();

--- a/DirectOutput/Log.cs
+++ b/DirectOutput/Log.cs
@@ -1,7 +1,4 @@
-﻿// Use #define DebugLog or #undef DebugLog to turn debug log messages on or off.
-#define DEBUGLOG
-
-using System;
+﻿using System;
 using System.IO;
 using System.Diagnostics;
 using System.Threading;

--- a/DirectOutput/Pinball.cs
+++ b/DirectOutput/Pinball.cs
@@ -155,7 +155,7 @@ namespace DirectOutput
                 try
                 {
                     Log.Filename = GlobalConfig.GetLogFilename((!TableFilename.IsNullOrWhiteSpace() ? new FileInfo(TableFilename).FullName : ""), RomName);
-                    Log.LogLevel = GlobalConfig.LogLevel;
+                    Log.Instrumentations = GlobalConfig.Instrumentation;
                     Log.Init();
                 }
                 catch (Exception E)

--- a/DirectOutput/Pinball.cs
+++ b/DirectOutput/Pinball.cs
@@ -155,6 +155,7 @@ namespace DirectOutput
                 try
                 {
                     Log.Filename = GlobalConfig.GetLogFilename((!TableFilename.IsNullOrWhiteSpace() ? new FileInfo(TableFilename).FullName : ""), RomName);
+                    Log.LogLevel = GlobalConfig.LogLevel;
                     Log.Init();
                 }
                 catch (Exception E)
@@ -214,7 +215,7 @@ namespace DirectOutput
                 }
                 if (Cabinet == null)
                 {
-                    Log.Write("No cabinet config file loaded. Will use AutoConfig.");
+                    Log.Warning("No cabinet config file loaded. Will use AutoConfig.");
                     //default to a new cabinet object if the config cant be loaded
                     Cabinet = new Cabinet();
                     Cabinet.AutoConfig();
@@ -334,8 +335,7 @@ namespace DirectOutput
                     }
                     else
                     {
-
-                        Log.Write("Cant load config from directoutput.ini or ledcontrol.ini file(s) since no RomName was supplied. No ledcontrol config will be loaded.");
+                        Log.Warning("Cant load config from directoutput.ini or ledcontrol.ini file(s) since no RomName was supplied. No ledcontrol config will be loaded.");
                     }
 
                 }


### PR DESCRIPTION
- New LogLevel in Log, default is Warning
- Error, Warning & Debug calls are filtered by LogLevel, Exception & Write are not
- GlobalConfig provide a LogLevel setting to Log (with check & error)
- Cleanup some Write calls -> Warning & Error
- Cleanup some Debug calls -> Write
- Didn't change some Write calls in SSFImpactor to Debug, could be spamming
- Remove compiled switch for Debug in Log & Dude's Cab code