### PR TITLE
Relax the rule that a color only is allowed in the second position

### DIFF
--- a/DirectOutput/LedControl/Loader/TableConfigSetting.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigSetting.cs
@@ -315,7 +315,7 @@ namespace DirectOutput.LedControl.Loader
 
                 if (ClosingBracketPos > 0)
                 {
-                    Condition = S.Substring(0, ClosingBracketPos + 1);
+                    Condition = S.Substring(0, ClosingBracketPos + 1).ToUpper();
                     OutputControl = OutputControlEnum.Condition;
                     S = S.Substring(Condition.Length).Trim();
                     //TODO: Maybe add a check for the condition validity
@@ -359,13 +359,13 @@ namespace DirectOutput.LedControl.Loader
                 }
                 if (TriggerEndPos == -1) TriggerEndPos = S.Length;
 
-                string Trigger = S.Substring(0, TriggerEndPos).Trim();
+                string Trigger = S.Substring(0, TriggerEndPos).ToUpper().Trim();
 
 
 
                 //Get output state and table element (if applicable)
                 bool ParseOK = true;
-                switch (Trigger.ToUpper())
+                switch (Trigger)
                 {
                     case "ON":
                     case "1":

--- a/DirectOutput/LedControl/Loader/TableConfigSetting.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigSetting.cs
@@ -291,7 +291,7 @@ namespace DirectOutput.LedControl.Loader
         /// </exception>
         public void ParseSettingData(string SettingData)
         {
-            string S = SettingData.Trim().ToUpper();
+            string S = SettingData.Trim();
 
             if (S.StartsWith("("))
             {
@@ -468,7 +468,7 @@ namespace DirectOutput.LedControl.Loader
                 }
                 else if (Parts[PartNr].Length > 3 && Parts[PartNr].Substring(0, 3).ToUpper() == "APC")
                 {
-                    ColorName2 = Parts[PartNr].Substring(3);
+                    ColorName2 = Parts[PartNr].Substring(3).ToUpper();
                     IsPlasma = true;
                     IsArea = true;
                 }
@@ -482,7 +482,7 @@ namespace DirectOutput.LedControl.Loader
 
                 else if (Parts[PartNr].Length > 3 && Parts[PartNr].Substring(0, 3).ToUpper() == "SHP" )
                 {
-                    ShapeName = Parts[PartNr].Substring(3).Trim();
+                    ShapeName = Parts[PartNr].Substring(3).Trim().ToUpper();
                     IsArea = true;
                 }
                 else if (Parts[PartNr].Length > 3 && Parts[PartNr].Substring(0, 3).ToUpper() == "ABT" && Parts[PartNr].Substring(3).IsInteger())
@@ -745,10 +745,16 @@ namespace DirectOutput.LedControl.Loader
                     }
                     IntegerCnt++;
                 }
-                else if (PartNr == 0)
+                // if Parts[PartNr] starts with capital letter and the rest small caps letters or underscore
+                else if (Parts[PartNr].Length > 2 && char.IsUpper(Parts[PartNr][0]) && Parts[PartNr].Skip(1).All(c => (char.IsLower(c) || c == '_')))
                 {
-                    //This should be a color
-                    ColorName = Parts[PartNr];
+                    // This should be a color
+                    ColorName = Parts[PartNr].ToUpper();
+                }
+                else if (Parts[PartNr].Length >= 7 && Parts[PartNr].Length <= 9 && Parts[PartNr][0] == '#' && Parts[PartNr].Substring(1).All(c => Uri.IsHexDigit(c)) )
+                {
+                    // This should be a color in hex format, e.g. #RRGGBB or #RRGGBBAA
+                    ColorName = Parts[PartNr].ToUpper();
                 }
                 else
                 {

--- a/DirectOutput/LedControl/Loader/TableConfigSetting.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigSetting.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using DirectOutput.FX.MatrixFX;
+using System;
 using System.Linq;
-using DirectOutput.FX.MatrixFX;
+using System.Text.RegularExpressions;
 
 namespace DirectOutput.LedControl.Loader
 {
@@ -745,15 +746,20 @@ namespace DirectOutput.LedControl.Loader
                     }
                     IntegerCnt++;
                 }
-                // if Parts[PartNr] starts with capital letter and the rest small caps letters or underscore
-                else if (Parts[PartNr].Length > 2 && char.IsUpper(Parts[PartNr][0]) && Parts[PartNr].Skip(1).All(c => (char.IsLower(c) || c == '_')))
+                // if Parts[PartNr] starts with # and a HTML-style hex color value we assume a color.
+                else if (Regex.IsMatch(Parts[PartNr], @"^#"))
                 {
-                    // This should be a color
+                    if (!Regex.IsMatch(Parts[PartNr], @"^#[0-9A-Fa-f]{6,8}$"))
+                    {
+                        Log.Warning("Invalid '#' HTML-style color code \"{0}\", #rrggbb or #rrggbbaa required".Build(Parts[PartNr]));
+                        throw new Exception("Invalid '#' HTML-style color code \"{0}\", #rrggbb or #rrggbbaa required".Build(Parts[PartNr]));
+                    }
+                    // This should be a HTML-style hex color string
                     ColorName = Parts[PartNr].ToUpper();
                 }
-                else if (Parts[PartNr].Length >= 7 && Parts[PartNr].Length <= 9 && Parts[PartNr][0] == '#' && Parts[PartNr].Substring(1).All(c => Uri.IsHexDigit(c)) )
+                // if Parts[PartNr] contains only capital and small caps letters or underscore we assume a color
+                else if (Parts[PartNr].Length > 2 && Regex.IsMatch(Parts[PartNr], @"^[A-Za-z_]+$"))
                 {
-                    // This should be a color in hex format, e.g. #RRGGBB or #RRGGBBAA
                     ColorName = Parts[PartNr].ToUpper();
                 }
                 else

--- a/DirectOutput/LedControl/Setup/Configurator.cs
+++ b/DirectOutput/LedControl/Setup/Configurator.cs
@@ -299,7 +299,7 @@ namespace DirectOutput.LedControl.Setup
                                             }
                                             else
                                             {
-                                                Log.Warning("No color valid color definition found for area effect. Skipped setting {0} in column {1} for LedWizEqivalent number {2}.".Build(SettingNumber, TCC.Number, LedWizNr));
+                                                Log.Warning("Invalid color definition \"{0}\" found for area effect. Skipped setting {1} in column {2} for LedWizEqivalent number {3}.".Build(TCS.ColorName, SettingNumber, TCC.Number, LedWizNr));
 
                                             }
                                         }


### PR DESCRIPTION
Relax the rule that a color has to be only in the second position in DOF configuration file.

As described in the ([DOF documentation](https://directoutput.github.io/DirectOutput/inifiles.html#inifiles_generalpara) the **Color name** or **Hex color definition** has to be placed in as the second value (e.g. S48 Blue). (Trigger Color)

I have been working with mberneis on the DOF Config tool to allow Templates to be defined. It means that even if there isn't many MX definitions available, you can build MX definitions based on the RGB or non color counterparts. (and maybe other things as well) 
For more details see [VP Universe](https://vpuniverse.com/forums/topic/11769-dof-config-tool-template-support/)

We do not want this template feature to know _to much_ about the DOF internals, rather simple text handling, which means if you add a color to a DOF configuration which has more than a trigger, your color addition would be placed further to the right, which make DOF fail.

With this change DOF would allow the following:

```
On Blink fu500 fd600 Red AT0 AL0
```

The part starting with **Red...** is added on top of the Start button configuration using a template, hence creating a MX configuration using the same trigger as the non colored one.

Even something like this would be "ok"

```
ON Blue AT0 AL0 AW100 AH100 Red
```

It means the **Red** *override* the **Blue** configuration. -> changing a preferred color...

Of course the old style configuration files will still work with this change.